### PR TITLE
Add dtoverlay support for 1-wire subsystem on H616 devices

### DIFF
--- a/arch/arm64/boot/dts/allwinner/overlay/Makefile
+++ b/arch/arm64/boot/dts/allwinner/overlay/Makefile
@@ -56,7 +56,8 @@ dtbo-$(CONFIG_ARCH_SUNXI) += \
 	sun50i-h616-i2c4.dtbo \
 	sun50i-h616-pwm12.dtbo \
 	sun50i-h616-pwm34.dtbo \
-	sun50i-h616-spi-spidev.dtbo
+	sun50i-h616-spi-spidev.dtbo \
+	sun50i-h616-w1-gpio.dtbo
 
 scr-$(CONFIG_ARCH_SUNXI) += \
 	sun50i-a64-fixup.scr \

--- a/arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-w1-gpio.dts
+++ b/arch/arm64/boot/dts/allwinner/overlay/sun50i-h616-w1-gpio.dts
@@ -1,0 +1,29 @@
+/dts-v1/;
+/plugin/;
+
+/ {
+        compatible = "allwinner,sun50i-h616";
+
+        fragment@0 {
+                target = <&pio>;
+                __overlay__ {
+                        w1_pins: w1_pins {
+                                pins = "PC10";
+                                function = "gpio_in";
+                        };
+                };
+        };
+
+        fragment@1 {
+                target-path = "/";
+                __overlay__ {
+                        onewire@0 {
+                                compatible = "w1-gpio";
+                                pinctrl-names = "default";
+                                pinctrl-0 = <&w1_pins>;
+                                gpios = <&pio 2 10 0>; /* PC10 */
+                                status = "okay";
+                        };
+                };
+        };
+};


### PR DESCRIPTION
Add dtoverlay support for 1-wire subsystem on H616 devices.

Successfully tested on Orangepi Zero 2.