### PR TITLE
fix otg mode on Orange Pi Zero2 H616

### DIFF
--- a/arch/arm64/boot/dts/allwinner/sun50i-h616-orangepi-zero2.dts
+++ b/arch/arm64/boot/dts/allwinner/sun50i-h616-orangepi-zero2.dts
@@ -107,10 +107,6 @@
 	status = "okay";
 };
 
-&ehci0 {
-	status = "okay";
-};
-
 &ehci1 {
 	status = "okay";
 };
@@ -173,10 +169,6 @@
 	bus-width = <4>;
 	non-removable;
 	mmc-ddr-1_8v;
-	status = "okay";
-};
-
-&ohci0 {
 	status = "okay";
 };
 


### PR DESCRIPTION
Since the ehci0 & ohci0 are enabled, the default turned on usbotg doesn't work correctly.