### PR TITLE
Fix dclk parent for hdmi vop0

### DIFF
--- a/arch/arm64/boot/dts/rockchip/rk3588s-orangepi.dtsi
+++ b/arch/arm64/boot/dts/rockchip/rk3588s-orangepi.dtsi
@@ -576,6 +576,9 @@
 
 /* vp0 & vp1 splice for 8K output */
 &vp0 {
+        /* Fix tty terminal out of screen, and most dclk of resolutions was not supported in hdmiphy clock from parent clock by default */
+        assigned-clocks = <&cru DCLK_VOP0>;
+        assigned-clock-parents = <&hdptxphy_hdmi_clk0>;
 	rockchip,plane-mask = <(1 << ROCKCHIP_VOP2_CLUSTER0 | 1 << ROCKCHIP_VOP2_ESMART0)>;
 	rockchip,primary-plane = <ROCKCHIP_VOP2_ESMART0>;
 };


### PR DESCRIPTION
Fix dclk parent for hdmi vop0 to solve tty terminal out of screen, and most dclk of resolutions was not supported in hdmiphy clock from parent clock by default.

- Before fix with same monitor:
```
root@orangepi5:/boot/dtb/rockchip# cat /sys/kernel/debug/clk/clk_summary | grep "hdmiphy" -A 1
       clk_hdmiphy_pixel0             1        2        0   148500000          0     0  50000
       usb480m_phy3                   2        4        0   480000000          0     0  50000
root@orangepi5:/boot/dtb/rockchip# cat /sys/class/drm/card0-HDMI-A-1/modes 
1920x1080
1280x1024
1280x720
800x600
720x480
720x480
```

- After fix with same monitor:

```
root@orangepi5:/home/orangepi/office/mhz# cat /sys/kernel/debug/clk/clk_summary | grep "hdmiphy" -A 1
       clk_hdmiphy_pixel0             2        3        0   106500000          0     0  50000
          dclk_vop0                   2        4        0   106500000          0     0  50000
root@orangepi5:/boot/dtb/rockchip# cat /sys/class/drm/card0-HDMI-A-1/modes 
1440x900
1920x1080
1920x1080
1280x1024
1280x1024
1280x720
1280x720
1024x768
1024x768
800x600
800x600
720x480
720x480
720x480
640x480
640x480
640x480
720x400
```
- 具体原理可参考“Rockchip_Developer_Guide_DRM_Display_Driver_CN.pdf”文档v3.5.1版本的47页
```
hdmi_phy0_pll, hdmi_phy1_pll 的特点如下：
1. ⽀持任意分频
2. HDMI 不⼯作时 VOP 独占 PLL，HDMI ⼯作时与 HDMI PHY 共享 PLL
3. HDMI 和 EDP 共⽤ PHY，EDP ⼯作时，PHY 上的 PLL ⽆法被 VOP 使⽤

对于 dclk_vp0/1/2， 可以指定 hdmi_phy0_pll, hdmi_phy1_pll, dclk_vpx_src0/1/2 中的⼀个作为其 parent clock, 对 dclk_vpx_src0/1/2，可以
指定
V0PLL, CPLL, GPLL, AUPLL 中的⼀个作为其 parent clock。
对于 dclk_vp3, 可以指定 V0PLL, CPLL, GPLL, AUPLL 中的⼀个作为其 parent clock。
V0PLL, CPLL, GPLL, AUPLL 为系统 CRU 上的 PLL，hdmi_phy0_pll 和 hdmi_phy1_pll 为 HDMI PHY 上的 PLL
VOPLL 的特点如下：
1. VOP 独占 PLL
2. ⽀持任意频率
3. dts 中默认与 dclk_vp2 绑定，代码如：
CPLL, GPLL, AUPLL 的特点如下：
1. 与其它 IP 模块共享 PLL
2. 不⽀持任意分频，输出频率为 PLL 频率的整数分频
3. dclk_vp0/1/3 默认与 GPLL 绑定
```

待测试（缺少屏幕，无法测试）：
1. 8K分辨率输出
2. 多屏显示