### PR TITLE
arm64: dts: rockchip: remove rule for overlay/rk3399-fixup.scr

### DIFF
--- a/arch/arm64/boot/dts/rockchip/overlay/Makefile
+++ b/arch/arm64/boot/dts/rockchip/overlay/Makefile
@@ -112,8 +112,7 @@ dtbo-$(CONFIG_ARCH_ROCKCHIP) += \
 
 scr-$(CONFIG_ARCH_ROCKCHIP) += \
 	rk3588-fixup.scr \
-	rk356x-fixup.scr \
-	rk3399-fixup.scr
+	rk356x-fixup.scr
 
 dtbotxt-$(CONFIG_ARCH_ROCKCHIP) += \
 	README.rockchip-overlays


### PR DESCRIPTION
rk3399-fixup.scr-cmd does not exist in tree, and it's not for rk35xx so it's not needed.

this fixes the following build issue:

```
make[3]: *** No rule to make target 'arch/arm64/boot/dts/rockchip/overlay/rk3399-fixup.scr', needed by '__build'.  Stop.
make[3]: *** Waiting for unfinished jobs....
make[2]: *** [scripts/Makefile.build:516: arch/arm64/boot/dts/rockchip/overlay] Error 2
make[1]: *** [scripts/Makefile.build:516: arch/arm64/boot/dts/rockchip] Error 2
make: *** [Makefile:1471: dtbs] Error 2
make: *** Waiting for unfinished jobs....
```