### PR TITLE
fix strobe CS between transfers

### DIFF
--- a/drivers/spi/spi-sunxi.c
+++ b/drivers/spi/spi-sunxi.c
@@ -1488,7 +1488,7 @@ static void sunxi_spi_work(struct work_struct *work)
 			if (t->delay_usecs)
 				udelay(t->delay_usecs);
 			/* if zero ,keep active,otherwise deactived. */
-			if (cs_change)
+			if (!cs_change)
 				sspi->cs_control(spi, 0);
 		}
 


### PR DESCRIPTION
.cs_change=1,达不到效果，查看源码，并修改测试实现cs_change=1时会持续拉低，.cs_change=0，再次恢复拉高状态