### PR TITLE
修改数据类型，解决使用arm官方工具链(aarch64-none-linux-gnu)编译报错的问题

### DIFF
--- a/drivers/cpufreq/sun50i-cpufreq-nvmem.c
+++ b/drivers/cpufreq/sun50i-cpufreq-nvmem.c
@@ -111,7 +111,7 @@ static int sun50i_cpufreq_get_efuse(const struct sunxi_cpufreq_soc_data *soc_dat
 static int sun50i_cpufreq_nvmem_probe(struct platform_device *pdev)
 {
 	const struct of_device_id *match;
-	struct opp_table **opp_tables;
+	int *opp_tables;
 	char name[MAX_NAME_LEN];
 	unsigned int cpu;
 	u32 speed = 0;


### PR DESCRIPTION
drivers/cpufreq/sun50i-cpufreq-nvmem.c:148:33: error: assignment to ‘struct opp_table *’ from ‘int’ makes pointer from integer without a cast [-Wint-conversion]
drivers/cpufreq/sun50i-cpufreq-nvmem.c:150:29: error: assignment to ‘int’ from ‘struct opp_table *’ makes integer from pointer without a cast [-Wint-conversion]
drivers/cpufreq/sun50i-cpufreq-nvmem.c:168:52: error: passing argument 1 of ‘dev_pm_opp_put_prop_name’ makes integer from pointer without a cast [-Wint-conversion]