### PR TITLE
Fix potential vulnerable cloned function

### DIFF
--- a/net/netfilter/nf_tables_api.c
+++ b/net/netfilter/nf_tables_api.c
@@ -7502,7 +7502,8 @@ static int nft_verdict_init(const struct nft_ctx *ctx, struct nft_data *data,
 			return PTR_ERR(chain);
 		if (nft_is_base_chain(chain))
 			return -EOPNOTSUPP;
-
+		if (nft_chain_is_bound(chain))
+			return -EINVAL;
 		chain->use++;
 		data->verdict.chain = chain;
 		break;


### PR DESCRIPTION
### Summary

Our tool detected a potential vulnerability in `net/netfilter/nf_tables_api.c` which was cloned from https://github.com/torvalds/linux/commit/e02f0d3970404bfea385b6edb86f2d936db0ea2b but did not receive the security patch. The original issue was reported and fixed under [CVE-2022-39190](https://nvd.nist.gov/vuln/detail/CVE-2022-39190).

### Proposed Fix

Apply the same patch as the one in torvalds/linux to eliminate the vulnerability.

### Reference

https://nvd.nist.gov/vuln/detail/CVE-2022-39190
https://github.com/torvalds/linux/commit/e02f0d3970404bfea385b6edb86f2d936db0ea2b