### PR TITLE
Fix USB-C DisplayPort hotplug on Orange Pi Zero 3W

### DIFF
--- a/bsp/drivers/drm/sunxi_drm_drv.c
+++ b/bsp/drivers/drm/sunxi_drm_drv.c
@@ -17,6 +17,7 @@
 #include <drm/drm_crtc_helper.h>
 #include <drm/drm_drv.h>
 #include <drm/drm_fb_helper.h>
+#include <drm/drm_fbdev_generic.h>
 #if LINUX_VERSION_CODE < KERNEL_VERSION(5, 19, 0)
 #include <drm/drm_gem_cma_helper.h>
 #else
@@ -1169,7 +1170,16 @@ static int sunxi_drm_bind(struct device *dev)
 
 dev_register:
 	ret = drm_dev_register(drm, 0);
-	//sunxi_drm_fbdev_init(drm);
+	if (ret)
+		goto mode_config_clean;
+
+	/*
+	 * USB-C DisplayPort becomes available only after Type-C altmode
+	 * negotiation, which normally completes after the DRM device has been
+	 * registered.  The generic fbdev client safely defers its initial setup
+	 * when no connector is ready and retries on the subsequent hotplug.
+	 */
+	drm_fbdev_generic_setup(drm, 32);
 
 #if IS_ENABLED(CONFIG_PROC_FS)
 	ret = sunxi_drm_procfs_init(drm);

--- a/bsp/drivers/usb/typec/mux/sunxi-phy-switcher.c
+++ b/bsp/drivers/usb/typec/mux/sunxi-phy-switcher.c
@@ -280,7 +280,15 @@ sunxi_phy_mux_set(struct typec_mux_dev *mux, struct typec_mux_state *state)
 		}
 
 		/* altmode displayport plugin */
-		if ((data->conf & DP_CONF_SIGNALING_DP) && (data->status & DP_STATUS_HPD_STATE))
+		/*
+		 * The DisplayPort altmode core passes the negotiated configuration
+		 * and HPD status while first putting the connector into SAFE mode.
+		 * Do not publish HPD at that point: the DP PHY has not been selected
+		 * yet and consumers will attempt AUX transfers before the mux is
+		 * ready.  Publish it when the subsequent DP mux state is applied.
+		 */
+		if (dp_mode && (data->conf & DP_CONF_SIGNALING_DP) &&
+		    (data->status & DP_STATUS_HPD_STATE))
 			phy_switcher->hpd_status = true;
 		else
 			phy_switcher->hpd_status = false;


### PR DESCRIPTION
Fixes #136.

## What this changes

This series fixes USB-C DisplayPort output on the Orange Pi Zero 3W in two
independently reviewable steps:

1. Delay the sunxi PHY switcher's DP HPD notification until the Type-C mux
   has entered a DP state. The altmode core supplies HPD during the preceding
   SAFE transition, but AUX is not usable until the DP PHY is selected.
2. Register the generic fbdev client after the sunxi DRM device is registered.
   Generic fbdev handles the case where USB-C DP becomes available later and
   retries setup on the hotplug event, providing a console on server images.

## Root cause

On the unpatched kernel, the event order was:

```text
STATE_SAFE with DP configuration and HPD high
seven AUX reply timeouts
STATE_SAFE -> STATE_DP_C
```

The SAFE callback set and published HPD. The later DP_C callback saw HPD
already cached as high, so it did not notify the eDP driver after the PHY had
become usable.

## Testing

Tested on:

- Orange Pi Zero 3W, Allwinner A733 / sun60iw2
- `orange-pi-6.6-sun60iw2` at `8a9be72c9`
- NXP PTN5002 USB-C adapter (`1fc9:5002`)
- ASUS VP28U DisplayPort monitor
- DP pin assignment C (four lanes)

The full kernel, modules, and DTBs build completed successfully. Both commits
pass `scripts/checkpatch.pl --strict` with zero errors and zero warnings.

The patched kernel was installed and cold-booted with the adapter connected.
It produced:

```text
DP_STATUS=connected
DP_ENABLED=enabled
EDID_BYTES=256
FB_NAME=sunxi-drmdrmfb
FB_MODE=U:3840x2160p-0
EXTCON=DP=1
```

The monitor exposes 28 modes. Direct DRM scanout was tested at 1920x1080 at
60 Hz, and automatic fbdev/tty1 scanout was verified at 3840x2160 at 30 Hz.
There were no AUX, PLL, or link-training errors, the kernel taint value was
zero, and no userspace modesetting process was running during the automatic
console test.

This does not include the two-lane DP+USB PLL change discussed in #133; the
tested adapter negotiated four-lane `TYPEC_DP_STATE_C`.
